### PR TITLE
Resolve CI / release script breaking for branch names with slashes

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -5,7 +5,8 @@ set -e
 last_tag=$(git tag --sort=-creatordate | head -n 1)
 new_tag=$(semver bump patch "$last_tag")
 timestamp=$(date -u +%Y%m%d%H%M%S)
-new_version=$(if [ "$BRANCH" = "master" ]; then echo "${new_tag}"; else echo "${new_tag}-${BRANCH}.$timestamp"; fi)
+ref=$(echo "$BRANCH" | sed -e 's/[^a-zA-Z0-9]/-/g')
+new_version=$(if [ "$ref" = "master" ]; then echo "${new_tag}"; else echo "${new_tag}-${BRANCH}.$timestamp"; fi)
 
 echo "Bump version: ${last_tag} -> ${new_version}"
 git tag "${new_version}"

--- a/release.sh
+++ b/release.sh
@@ -5,7 +5,7 @@ set -e
 last_tag=$(git tag --sort=-creatordate | head -n 1)
 new_tag=$(semver bump patch "$last_tag")
 timestamp=$(date -u +%Y%m%d%H%M%S)
-ref=$(echo "$BRANCH" | sed -e 's/[^a-zA-Z0-9]/-/g')
+ref=$(echo "$BRANCH" | sed -e 's/[^a-zA-Z0-9]//g')
 new_version=$(if [ "$ref" = "master" ]; then echo "${new_tag}"; else echo "${new_tag}-${ref}.$timestamp"; fi)
 
 echo "Bump version: ${last_tag} -> ${new_version}"

--- a/release.sh
+++ b/release.sh
@@ -6,7 +6,7 @@ last_tag=$(git tag --sort=-creatordate | head -n 1)
 new_tag=$(semver bump patch "$last_tag")
 timestamp=$(date -u +%Y%m%d%H%M%S)
 ref=$(echo "$BRANCH" | sed -e 's/[^a-zA-Z0-9]/-/g')
-new_version=$(if [ "$ref" = "master" ]; then echo "${new_tag}"; else echo "${new_tag}-${BRANCH}.$timestamp"; fi)
+new_version=$(if [ "$ref" = "master" ]; then echo "${new_tag}"; else echo "${new_tag}-${ref}.$timestamp"; fi)
 
 echo "Bump version: ${last_tag} -> ${new_version}"
 git tag "${new_version}"
@@ -18,7 +18,7 @@ docker tag "${IMAGE_NAME}" "${image_tag}"
 echo "Tagged docker image $image_tag"
 
 # If the branch is master, publish it.
-if [ "$BRANCH" = "master" ]; then
+if [ "$ref" = "master" ]; then
   # Login to Docker
   echo "${DOCKER_REGISTRY_PASSWORD}" | docker login -u "${DOCKER_REGISTRY_USERNAME}" --password-stdin
 

--- a/release.sh
+++ b/release.sh
@@ -5,7 +5,7 @@ set -e
 last_tag=$(git tag --sort=-creatordate | head -n 1)
 new_tag=$(semver bump patch "$last_tag")
 timestamp=$(date -u +%Y%m%d%H%M%S)
-ref=$(echo "$BRANCH" | sed -e 's/[^a-zA-Z0-9]//g')
+ref=$(echo "$BRANCH" | sed -e "s/[^a-zA-Z0-9]//g")
 new_version=$(if [ "$ref" = "master" ]; then echo "${new_tag}"; else echo "${new_tag}-${ref}.$timestamp"; fi)
 
 echo "Bump version: ${last_tag} -> ${new_version}"


### PR DESCRIPTION
Resolve CI / release script breaking for branch names with slashes. 

Required for pull requests like this one and https://github.com/laudio/pyodbc/pull/9 to work since the branch name is like `travis/branch/fix`.

### Changes
- Sanitized the branch name by stripping all the special characters before creating a release tag.

### Preview
Here's how the tag will be generated. 
![image](https://user-images.githubusercontent.com/3315763/66256853-0f654200-e7b2-11e9-93a3-369377ab1156.png)