### PR TITLE
Create crontol version, only generate version when change some files

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -8,6 +8,8 @@ timestamp=$(date -u +%Y%m%d%H%M%S)
 ref=$(echo "$BRANCH" | sed -e "s/[^a-zA-Z0-9]//g")
 new_version=$(if [ "$ref" = "master" ]; then echo "${new_tag}"; else echo "${new_tag}-${ref}.$timestamp"; fi)
 
+sensible_files=(Dockerfile .dockerignore requirements.txt)
+
 echo "Bump version: ${last_tag} -> ${new_version}"
 git tag "${new_version}"
 
@@ -17,17 +19,23 @@ docker tag "${IMAGE_NAME}" "${image_tag}"
 
 echo "Tagged docker image $image_tag"
 
+
 # If the branch is master, publish it.
 if [ "$ref" = "master" ]; then
-  # Login to Docker
-  echo "${DOCKER_REGISTRY_PASSWORD}" | docker login -u "${DOCKER_REGISTRY_USERNAME}" --password-stdin
-
-  # Push the newly tagged image to registry and GitHub
-  docker push "${image_tag}"
-  docker push "${IMAGE_NAME}:latest"
-  hub release create "${new_version}" -m "${new_version}" || true
-
-  echo "Published $image_tag"
+  for Item in ${sensible_files[*]} ;
+  do
+    compare_items=$(git diff --name-only HEAD~1..HEAD | grep $Item | grep -v example)
+    if [ "$Item" = "$compare_items" ] ; then
+      # Login to Docker
+      echo "${DOCKER_REGISTRY_PASSWORD}" | docker login -u "${DOCKER_REGISTRY_USERNAME}" --password-stdin
+      # Push the newly tagged image to registry and GitHub
+      docker push "${image_tag}"
+      docker push "${IMAGE_NAME}:latest"
+      hub release create "${new_version}" -m "${new_version}" || true
+      echo "Publish skipped"
+      continue
+    fi
+  done
 else
   echo "Publish skipped"
 fi

--- a/release.sh
+++ b/release.sh
@@ -2,40 +2,63 @@
 
 set -e
 
-last_tag=$(git tag --sort=-creatordate | head -n 1)
+last_tag=$(git tag | head -n 1)
 new_tag=$(semver bump patch "$last_tag")
 timestamp=$(date -u +%Y%m%d%H%M%S)
 ref=$(echo "$BRANCH" | sed -e "s/[^a-zA-Z0-9]//g")
 new_version=$(if [ "$ref" = "master" ]; then echo "${new_tag}"; else echo "${new_tag}-${ref}.$timestamp"; fi)
 
-sensible_files=(Dockerfile .dockerignore requirements.txt)
+validateFileChanges() {
+  #Define sensible file
+  sensible_files=(Dockerfile .dockerignore requirements.txt)
 
-echo "Bump version: ${last_tag} -> ${new_version}"
-git tag "${new_version}"
-
-# Create image tag
-image_tag="${IMAGE_NAME}:${new_version}"
-docker tag "${IMAGE_NAME}" "${image_tag}"
-
-echo "Tagged docker image $image_tag"
-
-
-# If the branch is master, publish it.
-if [ "$ref" = "master" ]; then
+  #Validate if sensible file are in list
   for Item in ${sensible_files[*]} ;
   do
     compare_items=$(git diff --name-only HEAD~1..HEAD | grep $Item | grep -v example)
     if [ "$Item" = "$compare_items" ] ; then
-      # Login to Docker
-      echo "${DOCKER_REGISTRY_PASSWORD}" | docker login -u "${DOCKER_REGISTRY_USERNAME}" --password-stdin
-      # Push the newly tagged image to registry and GitHub
-      docker push "${image_tag}"
-      docker push "${IMAGE_NAME}:latest"
-      hub release create "${new_version}" -m "${new_version}" || true
-      echo "Publish skipped"
-      continue
+        validateBranch
     fi
   done
-else
-  echo "Publish skipped"
-fi
+  echo "No need to make a new image. Publish skipped, bye!"
+}
+
+validateBranch() {
+  if [ "$ref" = "master" ]; then
+    echo "The branch is master"
+    tagged
+    publish
+  else
+    echo "Publish skipped, bye!"
+    exit 0
+  fi
+}
+
+tagged() {
+  echo "Bump version: ${last_tag} -> ${new_version}"
+  git tag "${new_version}"
+
+  # Create image tag
+  image_tag="${IMAGE_NAME}:${new_version}"
+  docker tag "${IMAGE_NAME}" "${image_tag}"
+
+  echo "Tagged docker image $image_tag"
+}
+
+publish() {
+  # Login to Docker
+  echo "${DOCKER_REGISTRY_PASSWORD}" | docker login -u "${DOCKER_REGISTRY_USERNAME}" --password-stdin
+  # Push the newly tagged image to registry and GitHub
+  docker push "${image_tag}"
+  docker push "${IMAGE_NAME}:latest"
+  hub release create "${new_version}" -m "${new_version}" || true
+
+  echo "A new version has been published"
+  exit 0
+}
+
+
+# Execution
+echo $(validateFileChanges)
+#tagged
+#publish

--- a/release.sh
+++ b/release.sh
@@ -12,7 +12,7 @@ validateFileChanges() {
   #Define sensible file
   sensible_files=(Dockerfile .dockerignore requirements.txt)
 
-  #Validate if sensible file are in list
+  # Validate if sensible file are in list.
   for Item in ${sensible_files[*]} ;
   do
     compare_items=$(git diff --name-only HEAD~1..HEAD | grep $Item | grep -v example)

--- a/release.sh
+++ b/release.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-last_tag=$(git tag | head -n 1)
+last_tag=$(git tag --sort=-creatordate| head -n 1)
 new_tag=$(semver bump patch "$last_tag")
 timestamp=$(date -u +%Y%m%d%H%M%S)
 ref=$(echo "$BRANCH" | sed -e "s/[^a-zA-Z0-9]//g")
@@ -34,7 +34,7 @@ validateBranch() {
   fi
 }
 
-tagged() {
+create_tag() {
   echo "Bump version: ${last_tag} -> ${new_version}"
   git tag "${new_version}"
 
@@ -60,5 +60,3 @@ publish() {
 
 # Execution
 echo $(validateFileChanges)
-#tagged
-#publish

--- a/release.sh
+++ b/release.sh
@@ -9,7 +9,7 @@ ref=$(echo "$BRANCH" | sed -e "s/[^a-zA-Z0-9]//g")
 new_version=$(if [ "$ref" = "master" ]; then echo "${new_tag}"; else echo "${new_tag}-${ref}.$timestamp"; fi)
 
 validateFileChanges() {
-  #Define sensible file
+  # Define a list of sensible files.
   sensible_files=(Dockerfile .dockerignore requirements.txt)
 
   # Validate if sensible file are in list.


### PR DESCRIPTION
Resolves https://github.com/laudio/pyodbc/issues/14

I created an array with the elements sensitive to change to create a new tag and a new version in dockerHub. To try to validate the changes, not having master these changes can execute in you terminal:
`sensible_files=(Dockerfile .dockerignore requirements.txt)`
`for Item in ${sensible_files[*]} ;
   do
     compare_items=$(git diff --name-only HEAD~16..HEAD | grep $Item | grep -v example)
     if [ "$Item" = "$compare_items" ] ; then
       echo $Item
       echo "Publish skipped"
       continue
     fi
   done`
