### PR TITLE
Upgrade base to python 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # STAGE: base
 # -----------
 # The main image that is published.
-FROM python:3.7-slim AS base
+FROM python:3.8-slim AS base
 
 COPY requirements.txt .
 


### PR DESCRIPTION
**Change**
Use python 3.8. Read more on what this includes here -https://www.python.org/downloads/release/python-380.

**Changelog:** https://docs.python.org/3/whatsnew/3.8.html

**Other Implications**
 - Size: 290MB -> 305MB :expressionless: 

**Note:** This is a significant change that affects all the dependent images that use it as a base; we need to do a minor bump (or major even) instead of a mere patch done by @laudio-bot.

