### PR TITLE
Prevent publish in minor changes

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -28,7 +28,6 @@ git log --oneline $COMMIT_RANGE
 changed_files=$(git diff --name-only $TRAVIS_COMMIT_RANGE)
 printfln "Changed file: $changed_files"
 
-# important file patterns
 important_file_pattern=(Dockerfile requirements.txt)
 
 # Loops for each file changes mentioned break if any found
@@ -42,7 +41,7 @@ for file in ${important_file_pattern[@]}; do
 done
 
 if [ -z "$changed" ]; then
-  echo "Seems like no major changes will be seen in published images...exiting !!"
+  echo "No changes detected, skipping release!"
   exit 0
 fi
 


### PR DESCRIPTION
closes https://github.com/laudio/pyodbc/issues/14
-  gets the commit ranges in PR
-  `important_file_pattern` includes list of file name patterns which requires the build of new image
   on any change
-  loop through the file names  if any changes spotted in any of  `important_file_pattern` , flag it and break and continue with publish script
- if no changes then exit without running any publish script
![Screenshot from 2020-06-06 21-52-55](https://user-images.githubusercontent.com/35683880/83948885-380d7200-a840-11ea-813c-dd712ef2061d.png)
