### PR TITLE
Update CommLog value to 0 in odbcinst.ini file for removing comm logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ script:
 
   # Spin up a mssql, pg & mysql database server containers
   - docker run --name test-mysql-server -e MYSQL_USER=${TEST_MYSQL_DB_USER} -e MYSQL_DATABASE=${TEST_MYSQL_DB_NAME} -e MYSQL_PASSWORD=${TEST_MYSQL_DB_PASSWORD} -d -p 3306:3306 mysql/mysql-server:latest
-  - docker run --name test-mssql-server -e ACCEPT_EULA=Y -e SA_PASSWORD=${TEST_MSSQL_DB_PASSWORD} -d -p 1433:1433 microsoft/mssql-server-linux:2017-GA
+  - docker run --name test-mssql-server -e ACCEPT_EULA=Y -e SA_PASSWORD=${TEST_MSSQL_DB_PASSWORD} -d -p 1433:1433 mcr.microsoft.com/mssql/server:2017-latest
   - docker run --name test-pg-server -e POSTGRES_USER=${TEST_PG_DB_USER} -e POSTGRES_DB=${TEST_PG_DB_NAME} -e POSTGRES_PASSWORD=${TEST_PG_DB_PASSWORD} -d -p 5432:5432 postgres
   - sleep 20s
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,11 +31,8 @@ RUN \
   myodbc-installer -a -d -n "MySQL ODBC 8.0" -t "Driver=/usr/local/lib/libmyodbc8a.so" && \
   apt-get install -y msodbcsql17 odbc-postgresql && \
   #
-  # Update odbcinst.ini to make sure full path to driver is listed
-  sed 's/Driver=psql/Driver=\/usr\/lib\/x86_64-linux-gnu\/odbc\/psql/' /etc/odbcinst.ini > /tmp/temp.ini && \
-  mv -f /tmp/temp.ini /etc/odbcinst.ini && \
-  # Update odbcinst.ini to set CommLog to 0. i.e disables any communication logs to be written to files
-  sed 's/CommLog=1/CommLog=0/' /etc/odbcinst.ini > /tmp/temp.ini && \
+  # Update odbcinst.ini to make sure full path to driver is listed, and set CommLog to 0. i.e disables any communication logs to be written to files
+  sed 's/Driver=psql/Driver=\/usr\/lib\/x86_64-linux-gnu\/odbc\/psql/;s/CommLog=1/CommLog=0/' /etc/odbcinst.ini > /tmp/temp.ini && \
   mv -f /tmp/temp.ini /etc/odbcinst.ini && \
   # Install dependencies
   pip install --upgrade pip && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # STAGE: base
 # -----------
 # The main image that is published.
-FROM python:3.10.5-slim AS base
+FROM python:3.7-slim AS base
 
 COPY requirements.txt .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN \
   # Update odbcinst.ini to make sure full path to driver is listed
   sed 's/Driver=psql/Driver=\/usr\/lib\/x86_64-linux-gnu\/odbc\/psql/' /etc/odbcinst.ini > /tmp/temp.ini && \
   mv -f /tmp/temp.ini /etc/odbcinst.ini && \
-  # Update odbcinst.ini to make sure full path to driver is listed
+  # Update odbcinst.ini to set CommLog to 0. i.e disables any communication logs to be written to files
   sed 's/CommLog=1/CommLog=0/' /etc/odbcinst.ini > /tmp/temp.ini && \
   mv -f /tmp/temp.ini /etc/odbcinst.ini && \
   # Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN \
   export MYSQL_CONNECTOR='mysql-connector-odbc-8.0.18-linux-glibc2.12-x86-64bit' && \
   export MYSQL_CONNECTOR_CHECKSUM='f2684bb246db22f2c9c440c4d905dde9' && \
   apt-get update && \
-  apt-get install -y curl build-essential unixodbc-dev g++ apt-transport-https && \
+  apt-get install -y curl build-essential g++ apt-transport-https && \
+  apt-get install -y --no-install-recommends unixodbc-dev && \
   gpg --keyserver keyserver.ubuntu.com --recv-keys 5072E1F5 && \
   #
   # Install pyodbc db drivers for MSSQL, PG and MySQL

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ RUN \
   apt-get update && \
   apt-get install -y curl && \
   curl -L -o multiarch-support_2.27-3ubuntu1_amd64.deb http://archive.ubuntu.com/ubuntu/pool/main/g/glibc/multiarch-support_2.27-3ubuntu1_amd64.deb && \
-  apt-get install ./multiarch-support_2.27-3ubuntu1_amd64.deb && \
-  apt-get install build-essential unixodbc-dev g++ apt-transport-https && \
+  apt-get install -y ./multiarch-support_2.27-3ubuntu1_amd64.deb && \
+  apt-get install -y build-essential unixodbc-dev g++ apt-transport-https && \
   gpg --keyserver keyserver.ubuntu.com --recv-keys 5072E1F5 && \
   #
   # Install pyodbc db drivers for MSSQL, PG and MySQL

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,9 @@ RUN \
   # Update odbcinst.ini to make sure full path to driver is listed
   sed 's/Driver=psql/Driver=\/usr\/lib\/x86_64-linux-gnu\/odbc\/psql/' /etc/odbcinst.ini > /tmp/temp.ini && \
   mv -f /tmp/temp.ini /etc/odbcinst.ini && \
+  # Update odbcinst.ini to make sure full path to driver is listed
+  sed 's/CommLog=1/CommLog=0/' /etc/odbcinst.ini > /tmp/temp.ini && \
+  mv -f /tmp/temp.ini /etc/odbcinst.ini && \
   # Install dependencies
   pip install --upgrade pip && \
   pip install -r requirements.txt && rm requirements.txt && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,10 @@ RUN \
   export MYSQL_CONNECTOR='mysql-connector-odbc-8.0.18-linux-glibc2.12-x86-64bit' && \
   export MYSQL_CONNECTOR_CHECKSUM='f2684bb246db22f2c9c440c4d905dde9' && \
   apt-get update && \
-  apt-get install -y curl build-essential g++ apt-transport-https && \
-  apt-get install -y --no-install-recommends unixodbc-dev && \
+  apt-get install -y curl && \
+  curl -L -o multiarch-support_2.27-3ubuntu1_amd64.deb http://archive.ubuntu.com/ubuntu/pool/main/g/glibc/multiarch-support_2.27-3ubuntu1_amd64.deb && \
+  apt-get install ./multiarch-support_2.27-3ubuntu1_amd64.deb && \
+  apt-get install build-essential unixodbc-dev g++ apt-transport-https && \
   gpg --keyserver keyserver.ubuntu.com --recv-keys 5072E1F5 && \
   #
   # Install pyodbc db drivers for MSSQL, PG and MySQL

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # STAGE: base
 # -----------
 # The main image that is published.
-FROM python:3.7-slim AS base
+FROM python:3.10.5-slim AS base
 
 COPY requirements.txt .
 
@@ -12,7 +12,7 @@ RUN \
   export MYSQL_CONNECTOR_CHECKSUM='f2684bb246db22f2c9c440c4d905dde9' && \
   apt-get update && \
   apt-get install -y curl build-essential unixodbc-dev g++ apt-transport-https && \
-  gpg --keyserver hkp://keys.gnupg.net --recv-keys 5072E1F5 && \
+  gpg --keyserver keyserver.ubuntu.com --recv-keys 5072E1F5 && \
   #
   # Install pyodbc db drivers for MSSQL, PG and MySQL
   curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # STAGE: base
 # -----------
 # The main image that is published.
-FROM python:3.7-slim AS base
+FROM python:3.10.5-slim AS base
 
 COPY requirements.txt .
 


### PR DESCRIPTION
Too many log files were being written every once in a while (while connection is being made/query being executed) which resulted in airflow server having low disk space in a timely manner. Manually setting the value inside the container prevented the log files being created. This PR aims to set the value permanently while being built. i.e
- Updated config variable CommLog to 0 in odbcinst.ini file 
