### PR TITLE
Update mysql driver and fix failing tests

### DIFF
--- a/images/pyodbc/Dockerfile
+++ b/images/pyodbc/Dockerfile
@@ -21,8 +21,8 @@ RUN \
   apt-get update && \
   gunzip ${MYSQL_CONNECTOR}.tar.gz && tar xvf ${MYSQL_CONNECTOR}.tar && \
   cp -r ${MYSQL_CONNECTOR}/bin/* /usr/local/bin && cp -r ${MYSQL_CONNECTOR}/lib/* /usr/local/lib && \
-  myodbc-installer -a -d -n "MySQL ODBC 8.0 Driver" -t "Driver=/usr/local/lib/libmyodbc8w.so" && \
-  myodbc-installer -a -d -n "MySQL ODBC 8.0" -t "Driver=/usr/local/lib/libmyodbc8a.so" && \
+  myodbc-installer -a -d -n "MySQL ODBC 8.0.33 Driver" -t "Driver=/usr/local/lib/libmyodbc8w.so" && \
+  myodbc-installer -a -d -n "MySQL ODBC 8.0.33" -t "Driver=/usr/local/lib/libmyodbc8a.so" && \
   apt-get install -y msodbcsql18 odbc-postgresql && \
   # Update odbcinst.ini to make sure full path to driver is listed, and set CommLog to 0. i.e disables any communication logs to be written to files
   sed 's/Driver=psql/Driver=\/usr\/lib\/x86_64-linux-gnu\/odbc\/psql/;s/CommLog=1/CommLog=0/' /etc/odbcinst.ini > /tmp/temp.ini && \

--- a/images/pyodbc/test/util.py
+++ b/images/pyodbc/test/util.py
@@ -21,7 +21,8 @@ CONN_STR: str = ';'.join([
     'PORT={port}',
     'DATABASE={database}',
     'UID={username}',
-    'PWD={password}'
+    'PWD={password}',
+    'TrustServerCertificate=yes'
 ])
 
 constr: Dict = {}
@@ -35,16 +36,16 @@ constr[PG] = lambda: CONN_STR.format(
 )
 
 constr[MSSQL] = lambda: CONN_STR.format(
-    driver='{ODBC Driver 17 for SQL Server}',
+    driver='{ODBC Driver 18 for SQL Server}',
     port=1433,
     server=os.environ['TEST_MSSQL_DB_HOST'],
     database=os.environ['TEST_MSSQL_DB_NAME'],
     username=os.environ['TEST_MSSQL_DB_USER'],
-    password=os.environ['TEST_MSSQL_DB_PASSWORD']
+    password=os.environ['TEST_MSSQL_DB_PASSWORD'],
 )
 
 constr[MYSQL] = lambda: CONN_STR.format(
-    driver='{MySQL ODBC 8.0 Driver}',
+    driver='{MySQL ODBC 8.0.33 Driver}',
     port=3306,
     server=os.environ['TEST_MYSQL_DB_HOST'],
     database=os.environ['TEST_MYSQL_DB_NAME'],


### PR DESCRIPTION
- Update mysql odbc driver version to `8.0.33` from `8.0`
- Use mssql odbc driver version 18
- Fixed failing test cases

![image](https://github.com/laudio/pyodbc/assets/34191173/875d435f-1bda-46ef-bedb-c2b6460bce4a)
